### PR TITLE
Anpassungen für WSC 6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -299,4 +299,9 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+# WSC Package Build Script
+build/
+build.sh
+.packageinfo
+
 # End of https://www.gitignore.io/api/git,linux,macos,windows,eclipse,intellij,phpstorm

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,8 +1,8 @@
 Hersteller:
 
 Niklas Friedrich Gerstner
-Heerstr. 12
-70563 Stuttgart
+Zwernitzer Str. 12
+81243 München
 Deutschland
 
 E-Mail: info@krymo.software
@@ -11,7 +11,7 @@ Internet: https://krymo.software
 
 § 1. Geltungsbereich
 
-1.1. Die nachfolgenden Lizenzbestimmungen beziehen sich auf alle von Niklas Friedrich Gerstner (im weiteren Hersteller genannt) kostenlos zur Verfügung gestellten Versionen der Produkte auf der Website https://www.woltlab.com/, https://krymo.software/, https://www.spigotmc.org/ und https://www.mc-market.org/, hergestellt durch Niklas Friedrich Gerstner.
+1.1. Die nachfolgenden Lizenzbestimmungen beziehen sich auf alle kostenlos zur Verfügung gestellten Versionen der Produkte auf den Websites https://www.woltlab.com/ und https://krymo.software/, die durch Niklas Friedrich Gerstner (im weiteren Hersteller genannt) hergestellt worden sind.
 
 1.2. Es gelten ausschließlich die Bestimmungen dieser Lizenzvereinbarung. Mündlichen Nebenabreden oder etwaigen Geschäftsbedingungen der herunterladenden Person werden bereits jetzt widersprochen.
 
@@ -47,7 +47,7 @@ Internet: https://krymo.software
 
 6.1. Im Hinblick auf sämtliche Rechtsbeziehungen aus diesen Lizenzbestimmungen gilt das Recht der Bundesrepublik Deutschland unter Ausschluss des UN-Kaufrechts.
 
-6.2. Sofern Sie Kaufmann im Sinne des Handelsgesetzbuches, juristische Person des öffentlichen Rechts oder öffentlich rechtliches Sondervermögen sind, wird für sämtliche Streitigkeiten, die im Rahmen der Abwicklung dieser Lizenzvereinbarung entstehen, Stuttgart als Gerichtstand vereinbart.
+6.2. Sofern Sie Kaufmann im Sinne des Handelsgesetzbuches, juristische Person des öffentlichen Rechts oder öffentlich rechtliches Sondervermögen sind, wird für sämtliche Streitigkeiten, die im Rahmen der Abwicklung dieser Lizenzvereinbarung entstehen, München als Gerichtstand vereinbart.
 
 
 --------------------
@@ -56,8 +56,8 @@ Internet: https://krymo.software
 Manufacturer:
 
 Niklas Friedrich Gerstner
-Heerstr. 12
-70563 Stuttgart
+Zwernitzer Str. 12
+81243 München
 Germany
 
 Email: info@krymo.software
@@ -66,7 +66,7 @@ Internet: https://krymo.software
 
 § 1. Scope of application
 
-1.1 The following license terms refer to all versions of the products provided free of charge by Niklas Friedrich Gerstner (hereinafter referred to as manufacturer) on the website https://www.woltlab.com/, https://krymo.software/, https://www.spigotmc.org/ and https://www.mc-market.org/, manufactured by Niklas Friedrich Gerstner.
+1.1 The following license terms refer to all versions of the products provided free of charge on the websites https://www.woltlab.com/ and https://krymo.software/ that were manufactured by Niklas Friedrich Gerstner (hereinafter referred to as manufacturer).
 
 1.2 The provisions of this license agreement apply exclusively. Oral subsidiary agreements or any terms and conditions of the person downloading are already contradicted now.
 
@@ -102,4 +102,4 @@ Internet: https://krymo.software
 
 6.1 The law of the Federal Republic of Germany shall apply with regard to all legal relationships arising from these license provisions, excluding the UN Convention on Contracts for the International Sale of Goods.
 
-6.2 If you are a merchant within the meaning of the German Commercial Code, a legal entity under public law or a special fund under public law, Stuttgart is agreed to be the place of jurisdiction for all disputes arising in connection with the execution of this license agreement.
+6.2 If you are a merchant within the meaning of the German Commercial Code, a legal entity under public law or a special fund under public law, München in Germany is agreed to be the place of jurisdiction for all disputes arising in connection with the execution of this license agreement.

--- a/bbcode.xml
+++ b/bbcode.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com https://www.woltlab.com/XSD/2019/bbcode.xsd">
-    <import>
-        <bbcode name="lang">
-            <classname>wcf\system\bbcode\LanguageBBCode</classname>
-            <isBlockElement>1</isBlockElement>
-            <attributes>
-                <attribute name="0">
-                    <required>1</required>
-                </attribute>
-            </attributes>
-        </bbcode>
-    </import>
+<data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/6.0/bbcode.xsd">
+	<import>
+		<bbcode name="lang">
+			<classname>wcf\system\bbcode\LanguageBBCode</classname>
+			<isBlockElement>1</isBlockElement>
+			<attributes>
+				<attribute name="0">
+					<required>1</required>
+				</attribute>
+			</attributes>
+		</bbcode>
+	</import>
 </data>

--- a/bbcode.xml
+++ b/bbcode.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/6.0/bbcode.xsd">
+<data xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/5.4/bbcode.xsd">
 	<import>
 		<bbcode name="lang">
 			<classname>wcf\system\bbcode\LanguageBBCode</classname>

--- a/files/lib/system/bbcode/LanguageBBCode.class.php
+++ b/files/lib/system/bbcode/LanguageBBCode.class.php
@@ -13,7 +13,7 @@ use wcf\system\WCF;
  * @license     Krymo Software - Free Products License <https://krymo.software/license-terms/#free-products>
  * @package     WoltLabSuite\Core\System\Bbcode
  */
-class LanguageBBCode extends AbstractBBCode
+final class LanguageBBCode extends AbstractBBCode
 {
     /**
      * @inheritDoc

--- a/files/lib/system/bbcode/LanguageBBCode.class.php
+++ b/files/lib/system/bbcode/LanguageBBCode.class.php
@@ -18,7 +18,7 @@ final class LanguageBBCode extends AbstractBBCode
     /**
      * @inheritDoc
      */
-    public function getParsedTag(array $openingTag, $content, array $closingTag, BBCodeParser $parser)
+    public function getParsedTag(array $openingTag, $content, array $closingTag, BBCodeParser $parser): string
     {
         $languageCode = !empty($openingTag['attributes'][0]) ? $openingTag['attributes'][0] : 0;
 

--- a/files/lib/system/bbcode/LanguageBBCode.class.php
+++ b/files/lib/system/bbcode/LanguageBBCode.class.php
@@ -28,7 +28,7 @@ final class LanguageBBCode extends AbstractBBCode
 
         $language = LanguageFactory::getInstance()->getLanguageByCode($languageCode);
 
-        if (!$language || WCF::getLanguage()->languageID != $language->languageID) {
+        if (!$language || WCF::getLanguage()->languageID !== $language->languageID) {
             return '';
         }
 

--- a/files/lib/system/bbcode/LanguageBBCode.class.php
+++ b/files/lib/system/bbcode/LanguageBBCode.class.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace wcf\system\bbcode;
 
 use wcf\system\language\LanguageFactory;
@@ -12,11 +13,13 @@ use wcf\system\WCF;
  * @license     Krymo Software - Free Products License <https://krymo.software/license-terms/#free-products>
  * @package     WoltLabSuite\Core\System\Bbcode
  */
-class LanguageBBCode extends AbstractBBCode {
+class LanguageBBCode extends AbstractBBCode
+{
     /**
      * @inheritDoc
      */
-    public function getParsedTag(array $openingTag, $content, array $closingTag, BBCodeParser $parser) {
+    public function getParsedTag(array $openingTag, $content, array $closingTag, BBCodeParser $parser)
+    {
         $languageCode = !empty($openingTag['attributes'][0]) ? $openingTag['attributes'][0] : 0;
 
         if (!$languageCode) {

--- a/files/lib/system/bbcode/LanguageBBCode.class.php
+++ b/files/lib/system/bbcode/LanguageBBCode.class.php
@@ -9,7 +9,7 @@ use wcf\system\WCF;
  * Parses the [lang] bbcode tag.
  *
  * @author      Niklas Friedrich Gerstner
- * @copyright   2020 Krymo Software
+ * @copyright   2024 Krymo Software
  * @license     Krymo Software - Free Products License <https://krymo.software/license-terms/#free-products>
  * @package     WoltLabSuite\Core\System\Bbcode
  */

--- a/package.xml
+++ b/package.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package name="software.krymo.woltlab.suite.core.bbcode.language" xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/2019/package.xsd">
-    <packageinformation>
-        <packagename><![CDATA[BBCode: Language]]></packagename>
-        <packagename language="de"><![CDATA[BBCode: Sprache]]></packagename>
-        <packagedescription><![CDATA[This package provides a language BBCode for the WoltLab Suite™ Core.]]></packagedescription>
-        <packagedescription language="de"><![CDATA[Dieses Paket stellt einen Sprach-BBCode für den WoltLab Suite™ Core zur Verfügung.]]></packagedescription>
-        <version>1.0.1</version>
-        <date>2020-04-26</date>
-        <packageurl><![CDATA[https://krymo.software]]></packageurl>
-    </packageinformation>
+<package name="software.krymo.woltlab.suite.core.bbcode.language" xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/6.0/package.xsd">
+	<packageinformation>
+		<packagename><![CDATA[BBCode: Language]]></packagename>
+		<packagename language="de"><![CDATA[BBCode: Sprache]]></packagename>
+		<packagedescription><![CDATA[This package provides a language BBCode for the WoltLab Suite™ Core.]]></packagedescription>
+		<packagedescription language="de"><![CDATA[Dieses Paket stellt einen Sprach-BBCode für den WoltLab Suite™ Core zur Verfügung.]]></packagedescription>
+		<version>1.0.1</version>
+		<date>2020-04-26</date>
+		<packageurl><![CDATA[https://krymo.software]]></packageurl>
+	</packageinformation>
 
-    <authorinformation>
-        <author><![CDATA[Krymo Software]]></author>
-        <authorurl><![CDATA[https://krymo.software]]></authorurl>
-    </authorinformation>
+	<authorinformation>
+		<author><![CDATA[Krymo Software]]></author>
+		<authorurl><![CDATA[https://krymo.software]]></authorurl>
+	</authorinformation>
 
-    <requiredpackages>
-        <requiredpackage minversion="3.1.0">com.woltlab.wcf</requiredpackage>
-    </requiredpackages>
+	<requiredpackages>
+		<requiredpackage minversion="3.1.0">com.woltlab.wcf</requiredpackage>
+	</requiredpackages>
 
-    <excludedpackages>
-        <excludedpackage version="6.0.0 Alpha 1">com.woltlab.wcf</excludedpackage>
-    </excludedpackages>
+	<excludedpackages>
+		<excludedpackage version="6.0.0 Alpha 1">com.woltlab.wcf</excludedpackage>
+	</excludedpackages>
 
-    <instructions type="install">
-        <instruction type="file"/>
-        <instruction type="bbcode"/>
-    </instructions>
+	<instructions type="install">
+		<instruction type="file"/>
+		<instruction type="bbcode"/>
+	</instructions>
 
-    <instructions type="update" fromversion="1.0.0">
-        <instruction type="file"/>
-        <instruction type="bbcode"/>
-    </instructions>
+	<instructions type="update" fromversion="1.0.0">
+		<instruction type="file"/>
+		<instruction type="bbcode"/>
+	</instructions>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -5,8 +5,8 @@
 		<packagename language="de"><![CDATA[BBCode: Sprache]]></packagename>
 		<packagedescription><![CDATA[This package provides a language BBCode for the WoltLab Suite™ Core.]]></packagedescription>
 		<packagedescription language="de"><![CDATA[Dieses Paket stellt einen Sprach-BBCode für den WoltLab Suite™ Core zur Verfügung.]]></packagedescription>
-		<version>1.0.1</version>
-		<date>2020-04-26</date>
+		<version>1.1.0</version>
+		<date>2023-10-24</date>
 		<packageurl><![CDATA[https://krymo.software]]></packageurl>
 	</packageinformation>
 
@@ -16,11 +16,11 @@
 	</authorinformation>
 
 	<requiredpackages>
-		<requiredpackage minversion="3.1.0">com.woltlab.wcf</requiredpackage>
+		<requiredpackage minversion="5.5.18">com.woltlab.wcf</requiredpackage>
 	</requiredpackages>
 
 	<excludedpackages>
-		<excludedpackage version="6.0.0 Alpha 1">com.woltlab.wcf</excludedpackage>
+		<excludedpackage version="7.0.0 Alpha 1">com.woltlab.wcf</excludedpackage>
 	</excludedpackages>
 
 	<instructions type="install">
@@ -28,8 +28,7 @@
 		<instruction type="bbcode"/>
 	</instructions>
 
-	<instructions type="update" fromversion="1.0.0">
+	<instructions type="update" fromversion="1.0.*">
 		<instruction type="file"/>
-		<instruction type="bbcode"/>
 	</instructions>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package name="software.krymo.woltlab.suite.core.bbcode.language" xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/6.0/package.xsd">
+<package name="software.krymo.woltlab.suite.core.bbcode.language" xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/5.4/package.xsd">
 	<packageinformation>
 		<packagename><![CDATA[BBCode: Language]]></packagename>
 		<packagename language="de"><![CDATA[BBCode: Sprache]]></packagename>
 		<packagedescription><![CDATA[This package provides a language BBCode for the WoltLab Suite™ Core.]]></packagedescription>
 		<packagedescription language="de"><![CDATA[Dieses Paket stellt einen Sprach-BBCode für den WoltLab Suite™ Core zur Verfügung.]]></packagedescription>
 		<version>1.1.0</version>
-		<date>2023-10-24</date>
+		<date>2024-01-01</date>
 		<packageurl><![CDATA[https://krymo.software]]></packageurl>
 	</packageinformation>
 
@@ -16,11 +16,11 @@
 	</authorinformation>
 
 	<requiredpackages>
-		<requiredpackage minversion="5.5.18">com.woltlab.wcf</requiredpackage>
+		<requiredpackage minversion="5.4.32">com.woltlab.wcf</requiredpackage>
 	</requiredpackages>
 
 	<excludedpackages>
-		<excludedpackage version="7.0.0 Alpha 1">com.woltlab.wcf</excludedpackage>
+		<excludedpackage version="6.1.0 Alpha 1">com.woltlab.wcf</excludedpackage>
 	</excludedpackages>
 
 	<instructions type="install">


### PR DESCRIPTION
Ich habe ein paar Anpassungen für WSC 6.0 vorgenommen:

- Umstellung des Codestyles auf PSR-12, welcher schon länger von WoltLab genutzt wird
- ich habe die Klasse `LanguageBBCode` `final` gemacht, da sie nicht geerbt werden darf
- ich habe den Rückgabetyp von `LanguageBBCode::getParsedTag` auf `string` gesetzt, da das nun notwendig ist
- ich habe die Einrückung die XML-Dateien angepasst, da es Tabs und keine Spaces sein sollten
- ich habe dir bereits die package.xml fürs Update angepasst ;)